### PR TITLE
change syles of snackbar on mobile

### DIFF
--- a/src/components/Snackbar/LoadingSnackbar/style.ts
+++ b/src/components/Snackbar/LoadingSnackbar/style.ts
@@ -24,12 +24,8 @@ export const StyledSnackbarContent = styled(SnackbarContent)(({ theme }) => ({
   },
 
   [theme.breakpoints.down('xs')]: {
-    maxWidth: 255,
-    padding: '0 6px',
-
-    '& p': {
-      ...typography.caption2
-    }
+    maxWidth: 'none',
+    width: 'auto'
   }
 }))
 

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -22,12 +22,17 @@ interface ISnackbarProps {
 }
 
 export const Snackbar: React.FC<ISnackbarProps> = ({ children, maxSnack }) => {
-  const isSmall = useMediaQuery(theme.breakpoints.down('sm'))
+  const isExSmall = useMediaQuery(theme.breakpoints.down('xs'))
 
   return (
     <SnackbarProvider
       dense
-      maxSnack={isSmall ? 5 : maxSnack}
+      maxSnack={isExSmall ? 5 : maxSnack}
+      anchorOrigin={
+        isExSmall
+          ? { vertical: 'top', horizontal: 'left' }
+          : { vertical: 'bottom', horizontal: 'left' }
+      }
       Components={{
         success: StyledMaterialDesignContent,
         error: StyledMaterialDesignContent,

--- a/src/components/Snackbar/style.ts
+++ b/src/components/Snackbar/style.ts
@@ -23,9 +23,8 @@ export const StyledMaterialDesignContent = styled(MaterialDesignContent)(({ them
       }
     },
     [theme.breakpoints.down('xs')]: {
-      ...typography.caption2,
-      maxWidth: 255,
-      padding: '0 6px'
+      maxWidth: 'none',
+      width: 'auto'
     }
   },
   '&.notistack-MuiContent-error': {
@@ -48,9 +47,8 @@ export const StyledMaterialDesignContent = styled(MaterialDesignContent)(({ them
       }
     },
     [theme.breakpoints.down('xs')]: {
-      ...typography.caption2,
-      maxWidth: 255,
-      padding: '0 6px'
+      maxWidth: 'none',
+      width: 'auto'
     }
   },
   '&.notistack-MuiContent-info': {
@@ -73,9 +71,8 @@ export const StyledMaterialDesignContent = styled(MaterialDesignContent)(({ them
       }
     },
     [theme.breakpoints.down('xs')]: {
-      ...typography.caption2,
-      maxWidth: 255,
-      padding: '0 6px'
+      maxWidth: 'none',
+      width: 'auto'
     }
   },
   '&.notistack-MuiContent-warning': {
@@ -98,9 +95,8 @@ export const StyledMaterialDesignContent = styled(MaterialDesignContent)(({ them
       }
     },
     [theme.breakpoints.down('xs')]: {
-      ...typography.caption2,
-      maxWidth: 255,
-      padding: '0 6px'
+      maxWidth: 'none',
+      width: 'auto'
     }
   }
 }))


### PR DESCRIPTION
change styles of snackbars on mobile:
- appear from the top
- full width of the screen 
- adjust font style

![Zrzut ekranu z 2024-03-28 10-29-22](https://github.com/invariant-labs/webapp/assets/93533892/ae95b03a-ed4b-4d6c-afea-9d53b976df53)
