### PR TITLE
disabled add liquidity when min and max are out of range

### DIFF
--- a/src/components/NewPosition/ConcentrationSlider/ConcentrationSlider.tsx
+++ b/src/components/NewPosition/ConcentrationSlider/ConcentrationSlider.tsx
@@ -7,6 +7,7 @@ export interface IProps {
   valueChangeHandler: (value: number) => void
   valueIndex: number
   dragHandler: (value: number) => void
+  minimumSliderIndex: number
 }
 
 interface ThumbProps extends React.HTMLAttributes<HTMLSpanElement> {
@@ -42,9 +43,15 @@ export const ConcentrationSlider: React.FC<IProps> = ({
   values,
   valueChangeHandler,
   valueIndex,
-  dragHandler
+  dragHandler,
+  minimumSliderIndex
 }) => {
-  const sliderClasses = useSliderStyles({ valuesLength: values.length })
+  const disabledPercentageRange = (100 * minimumSliderIndex) / values.length
+
+  const sliderClasses = useSliderStyles({
+    valuesLength: values.length,
+    disabledRange: disabledPercentageRange
+  })
 
   const onChangeCommited = useCallback(
     (_e: ChangeEvent<{}>, value: number | number[]) => {

--- a/src/components/NewPosition/ConcentrationSlider/style.ts
+++ b/src/components/NewPosition/ConcentrationSlider/style.ts
@@ -37,47 +37,60 @@ export const useThumbStyles = makeStyles(() => ({
   }
 }))
 
-export const useSliderStyles = makeStyles<Theme, { valuesLength: number }>(() => ({
-  root: {
-    width: '100%',
-    paddingBlock: 13
-  },
-  rail: {
-    background: colors.invariant.green,
-    height: 6,
-    opacity: 1
-  },
-  markLabel: ({ valuesLength }) => ({
-    color: colors.invariant.text,
-    ...typography.body1,
-    marginTop: 10,
-    top: 26,
-
-    '&[data-index="0"]': {
-      transform: 'translateX(-30%)'
+export const useSliderStyles = makeStyles<Theme, { valuesLength: number; disabledRange: number }>(
+  () => ({
+    root: {
+      width: '100%',
+      paddingBlock: 13
     },
-
-    [`&[data-index="${valuesLength - 1}"]`]: {
-      transform: 'translateX(-90%)'
-    }
-  }),
-  mark: ({ valuesLength }) => ({
-    display: 'none',
-
-    [`&[data-index="${valuesLength - 1}"], &[data-index="0"]`]: {
-      display: 'block',
-      width: 14,
-      height: 14,
-      borderRadius: '100%',
-      transform: 'translate(-6px, -4px)'
+    rail: ({ disabledRange }) => ({
+      background:
+        disabledRange > 0
+          ? `linear-gradient(90deg, ${colors.invariant.lightGrey} 0%, ${
+              colors.invariant.lightGrey
+            } ${disabledRange}%, ${colors.invariant.green} ${disabledRange + 1}%, ${
+              colors.invariant.green
+            } 100%)`
+          : colors.invariant.green,
+      height: 6,
+      opacity: 1
+    }),
+    track: {
+      background: colors.invariant.lightGrey,
+      height: 6
     },
+    markLabel: ({ valuesLength }) => ({
+      color: colors.invariant.text,
+      ...typography.body1,
+      marginTop: 10,
+      top: 26,
 
-    '&[data-index="0"]': {
-      background: colors.invariant.green
-    },
+      '&[data-index="0"]': {
+        transform: 'translateX(-30%)'
+      },
 
-    [`&[data-index="${valuesLength - 1}"]`]: {
-      background: colors.invariant.green
-    }
+      [`&[data-index="${valuesLength - 1}"]`]: {
+        transform: 'translateX(-90%)'
+      }
+    }),
+    mark: ({ valuesLength, disabledRange }) => ({
+      display: 'none',
+
+      [`&[data-index="${valuesLength - 1}"], &[data-index="0"]`]: {
+        display: 'block',
+        width: 14,
+        height: 14,
+        borderRadius: '100%',
+        transform: 'translate(-6px, -4px)'
+      },
+
+      '&[data-index="0"]': {
+        background: disabledRange > 0 ? colors.invariant.lightGrey : colors.invariant.green
+      },
+
+      [`&[data-index="${valuesLength - 1}"]`]: {
+        background: colors.invariant.green
+      }
+    })
   })
-}))
+)

--- a/src/components/NewPosition/DepositSelector/DepositSelector.tsx
+++ b/src/components/NewPosition/DepositSelector/DepositSelector.tsx
@@ -152,6 +152,17 @@ export const DepositSelector: React.FC<IDepositSelector> = ({
     }
 
     if (
+      concentrationIndex < minimumSliderIndex &&
+      isConcentrated &&
+      tokenAIndex !== null &&
+      tokenBIndex !== null
+    ) {
+      return concentrationArray[minimumSliderIndex]
+        ? `Set concentration to at least ${concentrationArray[minimumSliderIndex]}x`
+        : 'Set higher fee tier'
+    }
+
+    if (
       !tokenAInputState.blocked &&
       printBNtoBN(tokenAInputState.value, tokens[tokenAIndex].decimals).gt(
         tokens[tokenAIndex].balance
@@ -176,17 +187,6 @@ export const DepositSelector: React.FC<IDepositSelector> = ({
       +tokenBInputState.value === 0
     ) {
       return 'Liquidity must be greater than 0'
-    }
-
-    if (
-      concentrationIndex < minimumSliderIndex &&
-      isConcentrated &&
-      tokenAIndex !== null &&
-      tokenBIndex !== null
-    ) {
-      return concentrationArray[minimumSliderIndex]
-        ? `Set concentration to at least ${concentrationArray[minimumSliderIndex]}x`
-        : 'Set higher fee tier'
     }
 
     return 'Add Liquidity'

--- a/src/components/NewPosition/DepositSelector/DepositSelector.tsx
+++ b/src/components/NewPosition/DepositSelector/DepositSelector.tsx
@@ -151,12 +151,7 @@ export const DepositSelector: React.FC<IDepositSelector> = ({
       return 'Insufficient lamports'
     }
 
-    if (
-      concentrationIndex < minimumSliderIndex &&
-      isConcentrated &&
-      tokenAIndex !== null &&
-      tokenBIndex !== null
-    ) {
+    if (concentrationIndex < minimumSliderIndex && isConcentrated) {
       return concentrationArray[minimumSliderIndex]
         ? `Set concentration to at least ${concentrationArray[minimumSliderIndex]}x`
         : 'Set higher fee tier'
@@ -196,7 +191,8 @@ export const DepositSelector: React.FC<IDepositSelector> = ({
     tokenAInputState.value,
     tokenBInputState.value,
     tokens,
-    isConcentrated
+    isConcentrated,
+    concentrationIndex
   ])
 
   useEffect(() => {

--- a/src/components/NewPosition/DepositSelector/DepositSelector.tsx
+++ b/src/components/NewPosition/DepositSelector/DepositSelector.tsx
@@ -184,7 +184,9 @@ export const DepositSelector: React.FC<IDepositSelector> = ({
       tokenAIndex !== null &&
       tokenBIndex !== null
     ) {
-      return `Set concentration to at least ${concentrationArray[minimumSliderIndex]}x`
+      return concentrationArray[minimumSliderIndex]
+        ? `Set concentration to at least ${concentrationArray[minimumSliderIndex]}x`
+        : 'Set higher fee tier'
     }
 
     return 'Add Liquidity'

--- a/src/components/NewPosition/DepositSelector/DepositSelector.tsx
+++ b/src/components/NewPosition/DepositSelector/DepositSelector.tsx
@@ -3,6 +3,7 @@ import DepositAmountInput from '@components/Inputs/DepositAmountInput/DepositAmo
 import Select from '@components/Inputs/Select/Select'
 import {
   ALL_FEE_TIERS_DATA,
+  PositionOpeningMethod,
   WRAPPED_SOL_ADDRESS,
   WSOL_MIN_DEPOSIT_SWAP_FROM_AMOUNT,
   WSOL_POOL_INIT_LAMPORTS
@@ -60,7 +61,7 @@ export interface IDepositSelector {
   concentrationArray: number[]
   concentrationIndex: number
   minimumSliderIndex: number
-  isConcentrated: boolean
+  positionOpeningMethod: PositionOpeningMethod
 }
 
 export const DepositSelector: React.FC<IDepositSelector> = ({
@@ -92,7 +93,7 @@ export const DepositSelector: React.FC<IDepositSelector> = ({
   concentrationArray,
   concentrationIndex,
   minimumSliderIndex,
-  isConcentrated
+  positionOpeningMethod
 }) => {
   const classes = useStyles()
 
@@ -144,17 +145,17 @@ export const DepositSelector: React.FC<IDepositSelector> = ({
       return 'Select different tokens'
     }
 
+    if (positionOpeningMethod === 'concentration' && concentrationIndex < minimumSliderIndex) {
+      return concentrationArray[minimumSliderIndex]
+        ? `Set concentration to at least ${concentrationArray[minimumSliderIndex]}x`
+        : 'Set higher fee tier'
+    }
+
     if (
       (poolIndex === null && !canCreateNewPool) ||
       (poolIndex !== null && !canCreateNewPosition)
     ) {
       return 'Insufficient lamports'
-    }
-
-    if (concentrationIndex < minimumSliderIndex && isConcentrated) {
-      return concentrationArray[minimumSliderIndex]
-        ? `Set concentration to at least ${concentrationArray[minimumSliderIndex]}x`
-        : 'Set higher fee tier'
     }
 
     if (
@@ -191,8 +192,10 @@ export const DepositSelector: React.FC<IDepositSelector> = ({
     tokenAInputState.value,
     tokenBInputState.value,
     tokens,
-    isConcentrated,
-    concentrationIndex
+    positionOpeningMethod,
+    concentrationIndex,
+    feeTierIndex,
+    minimumSliderIndex
   ])
 
   useEffect(() => {

--- a/src/components/NewPosition/DepositSelector/DepositSelector.tsx
+++ b/src/components/NewPosition/DepositSelector/DepositSelector.tsx
@@ -57,6 +57,10 @@ export interface IDepositSelector {
   priceALoading?: boolean
   priceBLoading?: boolean
   feeTierIndex: number
+  concentrationArray: number[]
+  concentrationIndex: number
+  minimumSliderIndex: number
+  isConcentrated: boolean
 }
 
 export const DepositSelector: React.FC<IDepositSelector> = ({
@@ -84,7 +88,11 @@ export const DepositSelector: React.FC<IDepositSelector> = ({
   onHideUnknownTokensChange,
   priceALoading,
   priceBLoading,
-  feeTierIndex
+  feeTierIndex,
+  concentrationArray,
+  concentrationIndex,
+  minimumSliderIndex,
+  isConcentrated
 }) => {
   const classes = useStyles()
 
@@ -170,8 +178,24 @@ export const DepositSelector: React.FC<IDepositSelector> = ({
       return 'Liquidity must be greater than 0'
     }
 
+    if (
+      concentrationIndex < minimumSliderIndex &&
+      isConcentrated &&
+      tokenAIndex !== null &&
+      tokenBIndex !== null
+    ) {
+      return `Set concentration to at least ${concentrationArray[minimumSliderIndex]}x`
+    }
+
     return 'Add Liquidity'
-  }, [tokenAIndex, tokenBIndex, tokenAInputState.value, tokenBInputState.value, tokens])
+  }, [
+    tokenAIndex,
+    tokenBIndex,
+    tokenAInputState.value,
+    tokenBInputState.value,
+    tokens,
+    isConcentrated
+  ])
 
   useEffect(() => {
     if (tokenAIndex !== null) {

--- a/src/components/NewPosition/NewPosition.stories.tsx
+++ b/src/components/NewPosition/NewPosition.stories.tsx
@@ -119,14 +119,39 @@ storiesOf('position/newPosition', module)
             new PublicKey('9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E'),
             new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')
           ]}
-          initialIsConcentratedValue={false}
-          onIsConcentratedChange={() => {}}
+          initialOpeningPositionMethod={'range'}
+          onPositionOpeningMethodChange={() => {}}
           initialHideUnknownTokensValue={false}
           onHideUnknownTokensChange={() => {}}
           reloadHandler={() => {}}
           currentFeeIndex={feeIndex}
           onSlippageChange={() => {}}
           initialSlippage={'1'}
+          calculatePoolAddress={async () => await new Promise(() => {})}
+          copyPoolAddressHandler={() => {}}
+          history={{
+            length: 9,
+            action: 'REPLACE',
+            location: {
+              pathname: '/newPosition/USDC/SOL/0_05',
+              search: '',
+              hash: '',
+              state: undefined,
+              key: 'r2l2vi'
+            },
+            createHref: () => '',
+            push: () => {},
+            replace: () => {},
+            go: () => {},
+            goBack: () => {},
+            goForward: () => {},
+            block: () => () => {},
+            listen: () => () => ''
+          }}
+          initialFee='0_05'
+          initialTokenFrom='USDC'
+          initialTokenTo='SOL'
+          poolAddress=''
         />
       </div>
     )
@@ -195,14 +220,39 @@ storiesOf('position/newPosition', module)
             new PublicKey('9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E'),
             new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')
           ]}
-          initialIsConcentratedValue={false}
-          onIsConcentratedChange={() => {}}
+          initialOpeningPositionMethod={'range'}
+          onPositionOpeningMethodChange={() => {}}
           initialHideUnknownTokensValue={false}
           onHideUnknownTokensChange={() => {}}
           reloadHandler={() => {}}
           currentFeeIndex={feeIndex}
           onSlippageChange={() => {}}
           initialSlippage={'1'}
+          calculatePoolAddress={async () => await new Promise(() => {})}
+          copyPoolAddressHandler={() => {}}
+          history={{
+            length: 9,
+            action: 'REPLACE',
+            location: {
+              pathname: '/newPosition/USDC/SOL/0_05',
+              search: '',
+              hash: '',
+              state: undefined,
+              key: 'r2l2vi'
+            },
+            createHref: () => '',
+            push: () => {},
+            replace: () => {},
+            go: () => {},
+            goBack: () => {},
+            goForward: () => {},
+            block: () => () => {},
+            listen: () => () => ''
+          }}
+          initialFee='0_05'
+          initialTokenFrom='USDC'
+          initialTokenTo='SOL'
+          poolAddress=''
         />
       </div>
     )

--- a/src/components/NewPosition/NewPosition.tsx
+++ b/src/components/NewPosition/NewPosition.tsx
@@ -15,7 +15,7 @@ import {
 } from '@consts/utils'
 import { MIN_TICK } from '@invariant-labs/sdk'
 import { Decimal } from '@invariant-labs/sdk/lib/market'
-import { fromFee } from '@invariant-labs/sdk/lib/utils'
+import { fromFee, getConcentrationArray } from '@invariant-labs/sdk/lib/utils'
 import { MAX_TICK } from '@invariant-labs/sdk/src'
 import { Button, Grid, Typography } from '@material-ui/core'
 import { Color } from '@material-ui/lab'
@@ -26,7 +26,7 @@ import { PublicKey } from '@solana/web3.js'
 import backIcon from '@static/svg/back-arrow.svg'
 import settingIcon from '@static/svg/settings.svg'
 import { History } from 'history'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import ConcentrationTypeSwitch from './ConcentrationTypeSwitch/ConcentrationTypeSwitch'
 import DepositSelector from './DepositSelector/DepositSelector'
@@ -175,6 +175,11 @@ export const NewPosition: React.FC<INewPosition> = ({
   const [settings, setSettings] = React.useState<boolean>(false)
   const [slippTolerance, setSlippTolerance] = React.useState<string>(initialSlippage)
   const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null)
+
+  const [concentrationIndex, setConcentrationIndex] = useState(0)
+
+  const [minimumSliderIndex, setMinimumSliderIndex] = useState<number>(0)
+
   const setRangeBlockerInfo = () => {
     if (tokenAIndex === null || tokenBIndex === null) {
       return 'Select tokens to set price range.'
@@ -349,6 +354,11 @@ export const NewPosition: React.FC<INewPosition> = ({
     }
   }
 
+  const concentrationArray = useMemo(
+    () => getConcentrationArray(tickSpacing, 2, midPrice.index).sort((a, b) => a - b),
+    [tickSpacing, midPrice.index]
+  )
+
   return (
     <Grid container className={classes.wrapper} direction='column'>
       <Link to='/pool' style={{ textDecoration: 'none', maxWidth: 'fit-content' }}>
@@ -512,6 +522,10 @@ export const NewPosition: React.FC<INewPosition> = ({
           priceALoading={priceALoading}
           priceBLoading={priceBLoading}
           feeTierIndex={currentFeeIndex}
+          concentrationArray={concentrationArray}
+          concentrationIndex={concentrationIndex}
+          minimumSliderIndex={minimumSliderIndex}
+          isConcentrated={isConcentrated}
         />
 
         {isCurrentPoolExisting ||
@@ -554,6 +568,11 @@ export const NewPosition: React.FC<INewPosition> = ({
             hasTicksError={hasTicksError}
             reloadHandler={reloadHandler}
             volumeRange={plotVolumeRange}
+            concentrationArray={concentrationArray}
+            setConcentrationIndex={setConcentrationIndex}
+            concentrationIndex={concentrationIndex}
+            setMinimumSliderIndex={setMinimumSliderIndex}
+            minimumSliderIndex={minimumSliderIndex}
           />
         ) : (
           <PoolInit

--- a/src/components/NewPosition/NewPosition.tsx
+++ b/src/components/NewPosition/NewPosition.tsx
@@ -223,15 +223,32 @@ export const NewPosition: React.FC<INewPosition> = ({
   }
 
   const onChangeRange = (left: number, right: number) => {
-    setLeftRange(left)
-    setRightRange(right)
+    const leftMax = isXtoY ? getMinTick(tickSpacing) : getMaxTick(tickSpacing)
+    const rightMax = isXtoY ? getMaxTick(tickSpacing) : getMinTick(tickSpacing)
 
-    if (tokenAIndex !== null && (isXtoY ? right > midPrice.index : right < midPrice.index)) {
+    let leftInRange
+    let rightInRange
+
+    if (isXtoY) {
+      leftInRange = left < leftMax && !isConcentrated ? leftMax : left
+      rightInRange = right > rightMax && !isConcentrated ? rightMax : right
+    } else {
+      leftInRange = left > leftMax && !isConcentrated ? leftMax : left
+      rightInRange = right < rightMax && !isConcentrated ? rightMax : right
+    }
+
+    setLeftRange(leftInRange)
+    setRightRange(rightInRange)
+
+    if (
+      tokenAIndex !== null &&
+      (isXtoY ? rightInRange > midPrice.index : rightInRange < midPrice.index)
+    ) {
       const deposit = tokenADeposit
       const amount = getOtherTokenAmount(
         printBNtoBN(deposit, tokens[tokenAIndex].decimals),
-        left,
-        right,
+        leftInRange,
+        rightInRange,
         true
       )
 
@@ -243,12 +260,15 @@ export const NewPosition: React.FC<INewPosition> = ({
       }
     }
 
-    if (tokenBIndex !== null && (isXtoY ? left < midPrice.index : left > midPrice.index)) {
+    if (
+      tokenBIndex !== null &&
+      (isXtoY ? leftInRange < midPrice.index : leftInRange > midPrice.index)
+    ) {
       const deposit = tokenBDeposit
       const amount = getOtherTokenAmount(
         printBNtoBN(deposit, tokens[tokenBIndex].decimals),
-        left,
-        right,
+        leftInRange,
+        rightInRange,
         false
       )
 

--- a/src/components/NewPosition/RangeSelector/RangeSelector.tsx
+++ b/src/components/NewPosition/RangeSelector/RangeSelector.tsx
@@ -82,7 +82,7 @@ export const RangeSelector: React.FC<IRangeSelector> = ({
 
   const [leftInput, setLeftInput] = useState('')
   const [rightInput, setRightInput] = useState('')
-
+  console.log(rightRange)
   const [leftInputRounded, setLeftInputRounded] = useState('')
   const [rightInputRounded, setRightInputRounded] = useState('')
 
@@ -140,13 +140,27 @@ export const RangeSelector: React.FC<IRangeSelector> = ({
   }
 
   const changeRangeHandler = (left: number, right: number) => {
-    setLeftRange(left)
-    setRightRange(right)
+    const leftMax = isXtoY ? getMinTick(tickSpacing) : getMaxTick(tickSpacing)
+    const rightMax = isXtoY ? getMaxTick(tickSpacing) : getMinTick(tickSpacing)
 
-    setLeftInputValues(calcPrice(left, isXtoY, xDecimal, yDecimal).toString())
-    setRightInputValues(calcPrice(right, isXtoY, xDecimal, yDecimal).toString())
+    let leftInRange
+    let rightInRange
 
-    onChangeRange(left, right)
+    if (isXtoY) {
+      leftInRange = left < leftMax && !isConcentrated ? leftMax : left
+      rightInRange = right > rightMax && !isConcentrated ? rightMax : right
+    } else {
+      leftInRange = left > leftMax && !isConcentrated ? leftMax : left
+      rightInRange = right < rightMax && !isConcentrated ? rightMax : right
+    }
+
+    setLeftRange(leftInRange)
+    setRightRange(rightInRange)
+
+    setLeftInputValues(calcPrice(leftInRange, isXtoY, xDecimal, yDecimal).toString())
+    setRightInputValues(calcPrice(rightInRange, isXtoY, xDecimal, yDecimal).toString())
+
+    onChangeRange(leftInRange, rightInRange)
   }
 
   const resetPlot = () => {
@@ -275,6 +289,8 @@ export const RangeSelector: React.FC<IRangeSelector> = ({
       )
       changeRangeHandler(leftRange, rightRange)
       autoZoomHandler(leftRange, rightRange, true)
+    } else {
+      changeRangeHandler(leftRange, rightRange)
     }
   }, [isConcentrated])
 

--- a/src/components/NewPosition/RangeSelector/RangeSelector.tsx
+++ b/src/components/NewPosition/RangeSelector/RangeSelector.tsx
@@ -45,7 +45,6 @@ export interface IRangeSelector {
   }
   concentrationArray: number[]
   minimumSliderIndex: number
-  setMinimumSliderIndex: (val: number) => void
   concentrationIndex: number
   setConcentrationIndex: (val: number) => void
 }
@@ -73,7 +72,6 @@ export const RangeSelector: React.FC<IRangeSelector> = ({
   volumeRange,
   concentrationArray,
   minimumSliderIndex,
-  setMinimumSliderIndex,
   concentrationIndex,
   setConcentrationIndex
 }) => {
@@ -264,32 +262,6 @@ export const RangeSelector: React.FC<IRangeSelector> = ({
     }
   }
 
-  const getMinSliderIndex = () => {
-    let minimumSliderIndex = 0
-
-    for (let index = 0; index < concentrationArray.length; index++) {
-      const value = concentrationArray[index]
-      const { leftRange, rightRange } = calculateConcentrationRange(
-        tickSpacing,
-        value,
-        2,
-        midPrice.index,
-        isXtoY
-      )
-
-      const leftRangeValue = calcPrice(leftRange, isXtoY, xDecimal, yDecimal)
-      const rightRangeValue = calcPrice(rightRange, isXtoY, xDecimal, yDecimal)
-
-      if (leftRangeValue < data[0].x || rightRangeValue > data[1].x) {
-        minimumSliderIndex = index + 1
-      } else {
-        break
-      }
-    }
-
-    return minimumSliderIndex
-  }
-
   useEffect(() => {
     if (isConcentrated) {
       setConcentrationIndex(0)
@@ -325,13 +297,6 @@ export const RangeSelector: React.FC<IRangeSelector> = ({
       autoZoomHandler(leftRange, rightRange, true)
     }
   }, [midPrice.index, concentrationArray])
-
-  useEffect(() => {
-    if (isConcentrated) {
-      const minimumSliderIndex = getMinSliderIndex()
-      setMinimumSliderIndex(minimumSliderIndex)
-    }
-  }, [poolIndex, midPrice.index, isConcentrated])
 
   return (
     <Grid container className={classes.wrapper} direction='column'>

--- a/src/components/NewPosition/RangeSelector/RangeSelector.tsx
+++ b/src/components/NewPosition/RangeSelector/RangeSelector.tsx
@@ -46,9 +46,10 @@ export interface IRangeSelector {
   minimumSliderIndex: number
   concentrationIndex: number
   setConcentrationIndex: (val: number) => void
-  getMarkersInsideRange: (
+  getTicksInsideRange: (
     left: number,
-    right: number
+    right: number,
+    isXtoY: boolean
   ) => {
     leftInRange: number
     rightInRange: number
@@ -80,7 +81,7 @@ export const RangeSelector: React.FC<IRangeSelector> = ({
   minimumSliderIndex,
   concentrationIndex,
   setConcentrationIndex,
-  getMarkersInsideRange
+  getTicksInsideRange
 }) => {
   const classes = useStyles()
 
@@ -147,15 +148,25 @@ export const RangeSelector: React.FC<IRangeSelector> = ({
   }
 
   const changeRangeHandler = (left: number, right: number) => {
-    const { leftInRange, rightInRange } = getMarkersInsideRange(left, right)
+    let leftRange: number
+    let rightRange: number
 
-    setLeftRange(leftInRange)
-    setRightRange(rightInRange)
+    if (positionOpeningMethod === 'range') {
+      const { leftInRange, rightInRange } = getTicksInsideRange(left, right, isXtoY)
+      leftRange = leftInRange
+      rightRange = rightInRange
+    } else {
+      leftRange = left
+      rightRange = right
+    }
 
-    setLeftInputValues(calcPrice(leftInRange, isXtoY, xDecimal, yDecimal).toString())
-    setRightInputValues(calcPrice(rightInRange, isXtoY, xDecimal, yDecimal).toString())
+    setLeftRange(leftRange)
+    setRightRange(rightRange)
 
-    onChangeRange(leftInRange, rightInRange)
+    setLeftInputValues(calcPrice(leftRange, isXtoY, xDecimal, yDecimal).toString())
+    setRightInputValues(calcPrice(rightRange, isXtoY, xDecimal, yDecimal).toString())
+
+    onChangeRange(leftRange, rightRange)
   }
 
   const resetPlot = () => {

--- a/src/components/PositionDetails/SinglePositionPlot/SinglePositionPlot.tsx
+++ b/src/components/PositionDetails/SinglePositionPlot/SinglePositionPlot.tsx
@@ -4,7 +4,7 @@ import PriceRangePlot, { TickPlotPositionData } from '@components/PriceRangePlot
 import LiquidationRangeInfo from '@components/PositionDetails/LiquidationRangeInfo/LiquidationRangeInfo'
 import { calcPrice, spacingMultiplicityGte, calcTicksAmountInRange } from '@consts/utils'
 import { PlotTickData } from '@reducers/positions'
-import { MIN_TICK } from '@invariant-labs/sdk'
+import { getMinTick } from '@invariant-labs/sdk/lib/utils'
 import { ILiquidityToken } from '../SinglePositionInfo/consts'
 import PlotTypeSwitch from '@components/PlotTypeSwitch/PlotTypeSwitch'
 import activeLiquidity from '@static/svg/activeLiquidity.svg'
@@ -64,7 +64,7 @@ const SinglePositionPlot: React.FC<ISinglePositionPlot> = ({
       leftRange.x -
         calcPrice(
           Math.max(
-            spacingMultiplicityGte(MIN_TICK, tickSpacing),
+            spacingMultiplicityGte(getMinTick(tickSpacing), tickSpacing),
             leftRange.index - tickSpacing * 15
           ),
           xToY,

--- a/src/containers/NewPositionWrapper/NewPositionWrapper.tsx
+++ b/src/containers/NewPositionWrapper/NewPositionWrapper.tsx
@@ -1,7 +1,12 @@
 import { ProgressState } from '@components/AnimatedButton/AnimatedButton'
 import NewPosition from '@components/NewPosition/NewPosition'
 import { TickPlotPositionData } from '@components/PriceRangePlot/PriceRangePlot'
-import { ALL_FEE_TIERS_DATA, bestTiers, commonTokensForNetworks } from '@consts/static'
+import {
+  ALL_FEE_TIERS_DATA,
+  PositionOpeningMethod,
+  bestTiers,
+  commonTokensForNetworks
+} from '@consts/static'
 import {
   TokenPriceData,
   addNewTokenToLocalStorage,
@@ -12,11 +17,11 @@ import {
   getNewTokenOrThrow,
   printBN
 } from '@consts/utils'
-import { MAX_TICK, Pair, calculatePriceSqrt, getMarketAddress } from '@invariant-labs/sdk'
+import { Pair, calculatePriceSqrt, getMarketAddress } from '@invariant-labs/sdk'
 import { Decimal } from '@invariant-labs/sdk/lib/market'
 import { DECIMAL } from '@invariant-labs/sdk/lib/utils'
 import { getLiquidityByX, getLiquidityByY } from '@invariant-labs/sdk/src/math'
-import { feeToTickSpacing } from '@invariant-labs/sdk/src/utils'
+import { feeToTickSpacing, getMaxTick } from '@invariant-labs/sdk/src/utils'
 import { Color } from '@material-ui/lab'
 import { BN } from '@project-serum/anchor'
 import { actions as poolsActions } from '@reducers/pools'
@@ -287,12 +292,12 @@ export const NewPositionWrapper: React.FC<IProps> = ({
     )
   }
 
-  const initialIsConcentratedValue =
-    localStorage.getItem('IS_CONCENTRATED') === 'true' ||
-    localStorage.getItem('IS_CONCENTRATED') === null
+  const initialIsConcentrationOpening =
+    localStorage.getItem('OPENING_METHOD') === 'concentration' ||
+    localStorage.getItem('OPENING_METHOD') === null
 
-  const setIsConcentratedValue = (val: boolean) => {
-    localStorage.setItem('IS_CONCENTRATED', val ? 'true' : 'false')
+  const setPositionOpeningMethod = (val: PositionOpeningMethod) => {
+    localStorage.setItem('OPENING_METHOD', val)
   }
 
   const initialHideUnknownTokensValue =
@@ -370,7 +375,10 @@ export const NewPositionWrapper: React.FC<IProps> = ({
 
     const upperPrice = calcPrice(
       !lowerTicks.length || !upperTicks.length
-        ? Math.min(allPools[poolIndex].currentTickIndex + allPools[poolIndex].tickSpacing, MAX_TICK)
+        ? Math.min(
+            allPools[poolIndex].currentTickIndex + allPools[poolIndex].tickSpacing,
+            getMaxTick(tickSpacing)
+          )
         : Math.max(...upperTicks),
       isXtoY,
       xDecimal,
@@ -599,8 +607,8 @@ export const NewPositionWrapper: React.FC<IProps> = ({
       canCreateNewPosition={canUserCreateNewPosition}
       handleAddToken={addTokenHandler}
       commonTokens={commonTokensForNetworks[currentNetwork]}
-      initialIsConcentratedValue={initialIsConcentratedValue}
-      onIsConcentratedChange={setIsConcentratedValue}
+      initialOpeningPositionMethod={initialIsConcentrationOpening ? 'concentration' : 'range'}
+      onPositionOpeningMethodChange={setPositionOpeningMethod}
       initialHideUnknownTokensValue={initialHideUnknownTokensValue}
       onHideUnknownTokensChange={setHideUnknownTokensValue}
       tokenAPriceData={tokenAPriceData}

--- a/src/store/consts/static.ts
+++ b/src/store/consts/static.ts
@@ -367,3 +367,5 @@ export const SIGNING_SNACKBAR_CONFIG: Omit<ISnackbar, 'open'> = {
   variant: 'pending',
   persist: true
 }
+
+export type PositionOpeningMethod = 'range' | 'concentration'


### PR DESCRIPTION
Disabled 'add liquidity' when MIN and MAX are out of pool range.  Show the grey slider in a range that is disabled. 
![image](https://github.com/invariant-labs/webapp/assets/93533892/04d42584-c47d-4a89-85f8-65d026f9e578)
