### PR TITLE
add global price to the charts

### DIFF
--- a/src/components/Inputs/SimpleInput/SimpleInput.tsx
+++ b/src/components/Inputs/SimpleInput/SimpleInput.tsx
@@ -1,4 +1,4 @@
-import { Input } from '@material-ui/core'
+import { Input, Tooltip, Typography } from '@material-ui/core'
 import React, { CSSProperties, useRef } from 'react'
 import classNames from 'classnames'
 import useStyles from './style'
@@ -11,6 +11,7 @@ interface IProps {
   decimal: number
   placeholder?: string
   style?: CSSProperties
+  globalPrice?: number
 }
 
 export const AmountInput: React.FC<IProps> = ({
@@ -20,7 +21,8 @@ export const AmountInput: React.FC<IProps> = ({
   className,
   decimal,
   placeholder,
-  style
+  style,
+  globalPrice
 }) => {
   const classes = useStyles()
 
@@ -75,6 +77,24 @@ export const AmountInput: React.FC<IProps> = ({
       disableUnderline={true}
       placeholder={placeholder}
       onChange={allowOnlyDigitsAndTrimUnnecessaryZeros}
+      endAdornment={
+        globalPrice ? (
+          <Tooltip
+            title={
+              <Typography className={classes.textGlobalPrice} variant='caption'>
+                Global price
+              </Typography>
+            }
+            placement='right-start'
+            classes={{
+              tooltip: classes.globalPriceTooltip
+            }}>
+            <Typography className={classes.globalPrice} variant='h4'>
+              {globalPrice > 1 ? globalPrice.toFixed(2) : globalPrice}
+            </Typography>
+          </Tooltip>
+        ) : null
+      }
     />
   )
 }

--- a/src/components/Inputs/SimpleInput/SimpleInput.tsx
+++ b/src/components/Inputs/SimpleInput/SimpleInput.tsx
@@ -90,7 +90,7 @@ export const AmountInput: React.FC<IProps> = ({
               tooltip: classes.globalPriceTooltip
             }}>
             <Typography className={classes.globalPrice} variant='h4'>
-              {globalPrice > 1 ? globalPrice.toFixed(2) : globalPrice}
+              {globalPrice.toFixed(4)}
             </Typography>
           </Tooltip>
         ) : null

--- a/src/components/Inputs/SimpleInput/style.ts
+++ b/src/components/Inputs/SimpleInput/style.ts
@@ -9,13 +9,29 @@ const useStyles = makeStyles(() => ({
     ...typography.heading4,
     width: '100%',
     height: 48,
-    paddingInline: 16
+    paddingInline: 16,
+    display: 'flex'
   },
   input: {
     paddingTop: 4,
     '&:focus': {
       color: colors.white.main
-    }
+    },
+    flex: 1
+  },
+  globalPrice: {
+    color: colors.invariant.blue,
+    width: 'auto'
+  },
+  globalPriceTooltip: {
+    background: colors.invariant.component,
+    boxShadow: '0px 4px 18px rgba(0, 0, 0, 0.35)',
+    borderRadius: 8,
+    padding: '6px 8px',
+    boxSizing: 'border-box'
+  },
+  textGlobalPrice: {
+    ...typography.caption4
   }
 }))
 

--- a/src/components/NewPosition/NewPosition.tsx
+++ b/src/components/NewPosition/NewPosition.tsx
@@ -105,6 +105,7 @@ export interface INewPosition {
   currentFeeIndex: number
   onSlippageChange: (slippage: string) => void
   initialSlippage: string
+  globalPrice?: number
 }
 
 export const NewPosition: React.FC<INewPosition> = ({
@@ -156,7 +157,8 @@ export const NewPosition: React.FC<INewPosition> = ({
   plotVolumeRange,
   currentFeeIndex,
   onSlippageChange,
-  initialSlippage
+  initialSlippage,
+  globalPrice
 }) => {
   const classes = useStyles()
 
@@ -539,6 +541,7 @@ export const NewPosition: React.FC<INewPosition> = ({
               : {
                   data,
                   midPrice,
+                  globalPrice,
                   tokenASymbol: tokens[tokenAIndex].symbol,
                   tokenBSymbol: tokens[tokenBIndex].symbol
                 })}
@@ -567,6 +570,7 @@ export const NewPosition: React.FC<INewPosition> = ({
             midPrice={midPrice.index}
             onChangeMidPrice={onChangeMidPrice}
             currentPairReversed={currentPairReversed}
+            globalPrice={globalPrice}
           />
         )}
       </Grid>

--- a/src/components/NewPosition/PoolInit/PoolInit.tsx
+++ b/src/components/NewPosition/PoolInit/PoolInit.tsx
@@ -24,6 +24,7 @@ export interface IPoolInit {
   midPrice: number
   onChangeMidPrice: (mid: number) => void
   currentPairReversed: boolean | null
+  globalPrice?: number
 }
 
 export const PoolInit: React.FC<IPoolInit> = ({
@@ -36,7 +37,8 @@ export const PoolInit: React.FC<IPoolInit> = ({
   tickSpacing,
   midPrice,
   onChangeMidPrice,
-  currentPairReversed
+  currentPairReversed,
+  globalPrice
 }) => {
   const classes = useStyles()
 
@@ -132,6 +134,7 @@ export const PoolInit: React.FC<IPoolInit> = ({
           decimal={isXtoY ? xDecimal : yDecimal}
           className={classes.midPrice}
           placeholder='0.0'
+          globalPrice={globalPrice}
         />
 
         <Grid
@@ -140,7 +143,6 @@ export const PoolInit: React.FC<IPoolInit> = ({
           justifyContent='space-between'
           alignItems='center'>
           <Typography className={classes.priceLabel}>{tokenASymbol} starting price: </Typography>
-
           <Typography className={classes.priceValue}>
             <AnimatedNumber
               value={price.toFixed(isXtoY ? xDecimal : yDecimal)}

--- a/src/components/NewPosition/RangeSelector/RangeSelector.tsx
+++ b/src/components/NewPosition/RangeSelector/RangeSelector.tsx
@@ -22,6 +22,7 @@ import activeLiquidity from '@static/svg/activeLiquidity.svg'
 export interface IRangeSelector {
   data: PlotTickData[]
   midPrice: TickPlotPositionData
+  globalPrice?: number
   tokenASymbol: string
   tokenBSymbol: string
   onChangeRange: (leftIndex: number, rightIndex: number) => void
@@ -48,6 +49,7 @@ export interface IRangeSelector {
 export const RangeSelector: React.FC<IRangeSelector> = ({
   data,
   midPrice,
+  globalPrice,
   tokenASymbol,
   tokenBSymbol,
   onChangeRange,
@@ -310,7 +312,7 @@ export const RangeSelector: React.FC<IRangeSelector> = ({
         />
       </Grid>
       <Grid className={classes.infoRow} container justifyContent='flex-end'>
-        <Grid>
+        <Grid container direction='column' alignItems='flex-end'>
           <Tooltip
             title={
               <>
@@ -346,7 +348,10 @@ export const RangeSelector: React.FC<IRangeSelector> = ({
               Active liquidity <div className={classes.activeLiquidityIcon}>i</div>
             </Typography>
           </Tooltip>
-          <Typography className={classes.currentPrice}>Current price</Typography>
+          <Grid>
+            <Typography className={classes.currentPrice}>Current price</Typography>
+            <Typography className={classes.globalPrice}>Global price</Typography>
+          </Grid>
         </Grid>
       </Grid>
       <Grid container className={classes.innerWrapper}>
@@ -363,6 +368,7 @@ export const RangeSelector: React.FC<IRangeSelector> = ({
             x: calcPrice(rightRange, isXtoY, xDecimal, yDecimal)
           }}
           midPrice={midPrice}
+          globalPrice={globalPrice}
           plotMin={plotMin}
           plotMax={plotMax}
           zoomMinus={zoomMinus}

--- a/src/components/NewPosition/RangeSelector/style.ts
+++ b/src/components/NewPosition/RangeSelector/style.ts
@@ -211,9 +211,17 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginLeft: 16
   },
   currentPrice: {
+    display: 'inline-block',
     color: colors.invariant.yellow,
     ...typography.caption2,
     textAlign: 'right'
+  },
+  globalPrice: {
+    display: 'inline-block',
+    color: colors.invariant.blue,
+    ...typography.caption2,
+    textAlign: 'right',
+    marginLeft: 4
   }
 }))
 

--- a/src/components/PositionDetails/PositionDetails.tsx
+++ b/src/components/PositionDetails/PositionDetails.tsx
@@ -8,7 +8,7 @@ import { Button, Grid, Hidden, Typography } from '@material-ui/core'
 import { PlotTickData } from '@reducers/positions'
 import { PublicKey } from '@solana/web3.js'
 import backIcon from '@static/svg/back-arrow.svg'
-import React, { useState } from 'react'
+import React from 'react'
 import { Link, useHistory } from 'react-router-dom'
 import { ILiquidityToken } from './SinglePositionInfo/consts'
 import SinglePositionPlot from './SinglePositionPlot/SinglePositionPlot'
@@ -48,6 +48,9 @@ interface IProps {
     max: number
   }
   userHasStakes?: boolean
+  globalPrice?: number
+  setXToY: (val: boolean) => void
+  xToY: boolean
 }
 
 const PositionDetails: React.FC<IProps> = ({
@@ -77,13 +80,14 @@ const PositionDetails: React.FC<IProps> = ({
   hasTicksError,
   reloadHandler,
   plotVolumeRange,
-  userHasStakes = false
+  userHasStakes = false,
+  globalPrice,
+  setXToY,
+  xToY
 }) => {
   const classes = useStyles()
 
   const history = useHistory()
-
-  const [xToY, setXToY] = useState<boolean>(true)
 
   return (
     <Grid container className={classes.wrapperContainer} wrap='nowrap'>
@@ -184,6 +188,7 @@ const PositionDetails: React.FC<IProps> = ({
                   max: 1 / (plotVolumeRange?.min ?? 1)
                 }
           }
+          globalPrice={globalPrice}
         />
       </Grid>
     </Grid>

--- a/src/components/PositionDetails/SinglePositionPlot/SinglePositionPlot.tsx
+++ b/src/components/PositionDetails/SinglePositionPlot/SinglePositionPlot.tsx
@@ -15,6 +15,7 @@ export interface ISinglePositionPlot {
   leftRange: TickPlotPositionData
   rightRange: TickPlotPositionData
   midPrice: TickPlotPositionData
+  globalPrice?: number
   currentPrice: number
   tokenY: Pick<ILiquidityToken, 'name' | 'decimal'>
   tokenX: Pick<ILiquidityToken, 'name' | 'decimal'>
@@ -38,6 +39,7 @@ const SinglePositionPlot: React.FC<ISinglePositionPlot> = ({
   leftRange,
   rightRange,
   midPrice,
+  globalPrice,
   currentPrice,
   tokenY,
   tokenX,
@@ -118,7 +120,7 @@ const SinglePositionPlot: React.FC<ISinglePositionPlot> = ({
         />
       </Grid>
       <Grid className={classes.infoRow} container justifyContent='flex-end'>
-        <Grid>
+        <Grid container direction='column' alignItems='flex-end'>
           <Tooltip
             title={
               <>
@@ -154,7 +156,10 @@ const SinglePositionPlot: React.FC<ISinglePositionPlot> = ({
               Active liquidity <div className={classes.activeLiquidityIcon}>i</div>
             </Typography>
           </Tooltip>
-          <Typography className={classes.currentPrice}>Current price</Typography>
+          <Grid>
+            <Typography className={classes.currentPrice}>Current price</Typography>
+            <Typography className={classes.globalPrice}>Global price</Typography>
+          </Grid>
         </Grid>
       </Grid>
       <Grid className={classes.plotWrapper}>
@@ -179,6 +184,7 @@ const SinglePositionPlot: React.FC<ISinglePositionPlot> = ({
           hasError={hasTicksError}
           reloadHandler={reloadHandler}
           volumeRange={volumeRange}
+          globalPrice={globalPrice}
         />
       </Grid>
       <Grid className={classes.minMaxInfo}>

--- a/src/components/PositionDetails/SinglePositionPlot/style.ts
+++ b/src/components/PositionDetails/SinglePositionPlot/style.ts
@@ -136,9 +136,17 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginLeft: 16
   },
   currentPrice: {
+    display: 'inline-block',
     color: colors.invariant.yellow,
     ...typography.caption2,
     textAlign: 'right'
+  },
+  globalPrice: {
+    display: 'inline-block',
+    color: colors.invariant.blue,
+    ...typography.caption2,
+    textAlign: 'right',
+    marginLeft: 4
   }
 }))
 

--- a/src/components/PriceRangePlot/PriceRangePlot.tsx
+++ b/src/components/PriceRangePlot/PriceRangePlot.tsx
@@ -285,8 +285,8 @@ export const PriceRangePlot: React.FC<IPriceRangePlot> = ({
             <stop offset='100%' stop-color='black' stop-opacity='0' />
           </linearGradient>
         </defs>
-        <rect x={0} y={0} width={40} height={innerHeight} fill='url(#currentGradient)' />
-        <rect x={19} y={0} width={3} height={innerHeight} fill={colors.invariant.yellow} />
+        <rect x={0} y={20} width={40} height={innerHeight} fill='url(#currentGradient)' />
+        <rect x={19} y={20} width={3} height={innerHeight} fill={colors.invariant.yellow} />
       </svg>
     )
   }

--- a/src/components/PriceRangePlot/PriceRangePlot.tsx
+++ b/src/components/PriceRangePlot/PriceRangePlot.tsx
@@ -277,16 +277,14 @@ export const PriceRangePlot: React.FC<IPriceRangePlot> = ({
 
     const unitLen = innerWidth / (plotMax - plotMin)
     return (
-      <svg x={(midPrice.x - plotMin) * unitLen - 20} y={0} width={40} height={innerHeight}>
+      <svg x={(midPrice.x - plotMin) * unitLen - 20} y={0} width={60} height={innerHeight}>
         <defs>
-          <linearGradient id='currentGradient'>
-            <stop offset='0%' stop-color='black' stop-opacity='0' />
-            <stop offset='50%' stop-color='black' stop-opacity='0.25' />
-            <stop offset='100%' stop-color='black' stop-opacity='0' />
-          </linearGradient>
+          <filter id='shadow' x='-10' y='-9' width='20' height={innerHeight}>
+            <feGaussianBlur in='SourceGraphic' stdDeviation='8' />
+          </filter>
         </defs>
-        <rect x={0} y={20} width={40} height={innerHeight} fill='url(#currentGradient)' />
-        <rect x={19} y={20} width={3} height={innerHeight} fill={colors.invariant.yellow} />
+        <rect x={14} y={20} width='16' height={innerHeight} filter='url(#shadow)' opacity='0.3' />
+        <rect x={19} y={20} width='3' height={innerHeight} fill={colors.invariant.yellow} />
       </svg>
     )
   }
@@ -298,16 +296,21 @@ export const PriceRangePlot: React.FC<IPriceRangePlot> = ({
 
     const unitLen = innerWidth / (plotMax - plotMin)
     return (
-      <svg x={(globalPrice - plotMin) * unitLen - 20} y={0} width={40} height={innerHeight}>
+      <svg x={(globalPrice - plotMin) * unitLen - 20} y={-20} width={40} height={innerHeight + 20}>
         <defs>
-          <linearGradient id='currentGradient'>
-            <stop offset='0%' stop-color='black' stop-opacity='0' />
-            <stop offset='50%' stop-color='black' stop-opacity='0.25' />
-            <stop offset='100%' stop-color='black' stop-opacity='0' />
-          </linearGradient>
+          <filter id='shadow-global-price' x='-10' y='-9' width='20' height={innerHeight}>
+            <feGaussianBlur in='SourceGraphic' stdDeviation='8' />
+          </filter>
         </defs>
-        <rect x={0} y={0} width={40} height={innerHeight} fill='url(#currentGradient)' />
-        <rect x={19} y={0} width={3} height={innerHeight} fill={colors.invariant.blue} />
+        <rect
+          x={14}
+          y={20}
+          width='16'
+          height={innerHeight}
+          filter='url(#shadow-global-price)'
+          opacity='0.3'
+        />
+        <rect x={19} y={20} width='3' height={innerHeight} fill={colors.invariant.blue} />
       </svg>
     )
   }

--- a/src/components/PriceRangePlot/PriceRangePlot.tsx
+++ b/src/components/PriceRangePlot/PriceRangePlot.tsx
@@ -18,6 +18,7 @@ export type TickPlotPositionData = Omit<PlotTickData, 'y'>
 export interface IPriceRangePlot {
   data: PlotTickData[]
   midPrice?: TickPlotPositionData
+  globalPrice?: number
   leftRange: TickPlotPositionData
   rightRange: TickPlotPositionData
   onChangeRange?: (left: number, right: number) => void
@@ -48,6 +49,7 @@ export const PriceRangePlot: React.FC<IPriceRangePlot> = ({
   leftRange,
   rightRange,
   midPrice,
+  globalPrice,
   onChangeRange,
   style,
   className,
@@ -289,6 +291,27 @@ export const PriceRangePlot: React.FC<IPriceRangePlot> = ({
     )
   }
 
+  const globalPriceLayer: Layer = ({ innerWidth, innerHeight }) => {
+    if (typeof globalPrice === 'undefined') {
+      return null
+    }
+
+    const unitLen = innerWidth / (plotMax - plotMin)
+    return (
+      <svg x={(globalPrice - plotMin) * unitLen - 20} y={0} width={40} height={innerHeight}>
+        <defs>
+          <linearGradient id='currentGradient'>
+            <stop offset='0%' stop-color='black' stop-opacity='0' />
+            <stop offset='50%' stop-color='black' stop-opacity='0.25' />
+            <stop offset='100%' stop-color='black' stop-opacity='0' />
+          </linearGradient>
+        </defs>
+        <rect x={0} y={0} width={40} height={innerHeight} fill='url(#currentGradient)' />
+        <rect x={19} y={0} width={3} height={innerHeight} fill={colors.invariant.blue} />
+      </svg>
+    )
+  }
+
   const volumeRangeLayer: Layer = ({ innerWidth, innerHeight }) => {
     if (typeof volumeRange === 'undefined') {
       return null
@@ -478,6 +501,7 @@ export const PriceRangePlot: React.FC<IPriceRangePlot> = ({
           'areas',
           'lines',
           lazyLoadingLayer,
+          globalPriceLayer,
           currentLayer,
           volumeRangeLayer,
           brushLayer,

--- a/src/containers/NewPositionWrapper/NewPositionWrapper.tsx
+++ b/src/containers/NewPositionWrapper/NewPositionWrapper.tsx
@@ -9,6 +9,7 @@ import {
   calcYPerXPrice,
   createPlaceholderLiquidityPlot,
   getJupTokenPrice,
+  getJupTokensRatioPrice,
   getNewTokenOrThrow,
   printBN
 } from '@consts/utils'
@@ -80,6 +81,8 @@ export const NewPositionWrapper: React.FC<IProps> = ({
   const [tokenBIndex, setTokenBIndex] = useState<number | null>(null)
 
   const [currentPairReversed, setCurrentPairReversed] = useState<boolean | null>(null)
+
+  const [globalPrice, setGlobalPrice] = useState<number | undefined>(undefined)
 
   useEffect(() => {
     setProgress('none')
@@ -324,6 +327,23 @@ export const NewPositionWrapper: React.FC<IProps> = ({
 
   const [tokenBPriceData, setTokenBPriceData] = useState<TokenPriceData | undefined>(undefined)
   const [priceBLoading, setPriceBLoading] = useState(false)
+  useEffect(() => {
+    if (tokenAIndex === null || tokenBIndex === null) {
+      return
+    }
+
+    const tokenAId = tokens[tokenBIndex].assetAddress.toString() ?? ''
+    const tokenBId = tokens[tokenAIndex].assetAddress.toString() ?? ''
+
+    if (tokenAId.length && tokenBId.length) {
+      getJupTokensRatioPrice(tokenBId, tokenAId)
+        .then(data => setGlobalPrice(data.price))
+        .catch(() => setGlobalPrice(undefined))
+    } else {
+      setGlobalPrice(undefined)
+    }
+  }, [tokenAIndex, tokenBIndex])
+
   useEffect(() => {
     if (tokenBIndex === null) {
       return
@@ -624,6 +644,7 @@ export const NewPositionWrapper: React.FC<IProps> = ({
       currentFeeIndex={feeIndex}
       onSlippageChange={onSlippageChange}
       initialSlippage={initialSlippage}
+      globalPrice={globalPrice}
     />
   )
 }

--- a/src/static/theme.ts
+++ b/src/static/theme.ts
@@ -84,7 +84,8 @@ export const colors = {
     pinkLinearGradient: 'linear-gradient(180deg, #EF84F5 0%, #9C3EBD 100%)',
     pinkLinearGradientOpacity:
       'linear-gradient(180deg, rgba(239, 132, 245, 0.8) 0%, rgba(156, 62, 189, 0.8) 100%)',
-    yellow: '#EFD063'
+    yellow: '#EFD063',
+    blue: '#43BBFF'
   }
 }
 

--- a/src/store/consts/utils.ts
+++ b/src/store/consts/utils.ts
@@ -1064,6 +1064,13 @@ export const getJupTokenPrice = async (id: string): Promise<TokenPriceData> => {
   }
 }
 
+export const getJupTokensRatioPrice = async (id: string, vsId: string): Promise<TokenPriceData> => {
+  const response = await axios.get(`https://price.jup.ag/v4/price?ids=${id}&vsToken=${vsId}`)
+  return {
+    price: response.data.data[id].price ?? 0
+  }
+}
+
 export const getTicksList = async (
   marketProgram: Market,
   data: Array<{ pair: Pair; index: number }>


### PR DESCRIPTION
Add global price to:
- position details
- adding new pool
- adding new position

#### Global price should be included in handling the refresh button after this merge. 

![image](https://github.com/invariant-labs/webapp/assets/93533892/5ad3a33c-f1b2-49cc-933d-f7390e979412)

![image](https://github.com/invariant-labs/webapp/assets/93533892/c97e5fb4-e3b7-458a-afaa-86e5b499d463)

![image](https://github.com/invariant-labs/webapp/assets/93533892/0c8e4ed1-5230-48da-b695-926829d8d2b7)

changed styles of shadows for current and global price:


![image](https://github.com/invariant-labs/webapp/assets/93533892/7a76a6b4-02db-4513-959d-392cfe9f340b)
