### PR TITLE
fix rendering marketId in new position from position details

### DIFF
--- a/src/components/NewPosition/NewPosition.tsx
+++ b/src/components/NewPosition/NewPosition.tsx
@@ -315,7 +315,7 @@ export const NewPosition: React.FC<INewPosition> = ({
       setAddress(configuredAddress)
     }
     void configurePoolAddress()
-  }, [initialTokenFrom, initialTokenTo, initialFee])
+  }, [initialTokenFrom, initialTokenTo, initialFee, poolAddress, address])
 
   const handleClickSettings = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget)


### PR DESCRIPTION
fix rendering marketId when new position is open from position details page 