### PR TITLE
standarize sizes of interface for position details and new position pages

### DIFF
--- a/src/components/NewPosition/DepositSelector/style.ts
+++ b/src/components/NewPosition/DepositSelector/style.ts
@@ -52,7 +52,7 @@ const useStyles = makeStyles(() => ({
   },
   addButton: {
     width: '100%',
-    marginTop: 24,
+    margin: '30px 0',
     cursor: 'default'
   },
   hoverButton: {

--- a/src/components/NewPosition/PoolInit/PoolInit.tsx
+++ b/src/components/NewPosition/PoolInit/PoolInit.tsx
@@ -115,44 +115,45 @@ export const PoolInit: React.FC<IPoolInit> = ({
 
   return (
     <Grid container direction='column' className={classes.wrapper}>
-      <Typography className={classes.header}>Starting price</Typography>
       <Grid
         container
         className={classes.innerWrapper}
         direction='column'
         justifyContent='flex-start'>
-        <Grid className={classes.infoWrapper}>
-          <Typography className={classes.info}>
-            This pool does not exist yet. To create it, select the fee tier, initial price, and
-            enter the amount of tokens. The estimated cost of creating a pool is 0.1 SOL.
-          </Typography>
+        <Grid className={classes.topInnerWrapper}>
+          <Typography className={classes.header}>Starting price</Typography>
+          <Grid className={classes.infoWrapper}>
+            <Typography className={classes.info}>
+              This pool does not exist yet. To create it, select the fee tier, initial price, and
+              enter the amount of tokens. The estimated cost of creating a pool is 0.1 SOL.
+            </Typography>
+          </Grid>
+
+          <SimpleInput
+            setValue={setMidPriceInput}
+            value={midPriceInput}
+            decimal={isXtoY ? xDecimal : yDecimal}
+            className={classes.midPrice}
+            placeholder='0.0'
+            globalPrice={globalPrice}
+          />
+
+          <Grid
+            className={classes.priceWrapper}
+            container
+            justifyContent='space-between'
+            alignItems='center'>
+            <Typography className={classes.priceLabel}>{tokenASymbol} starting price: </Typography>
+            <Typography className={classes.priceValue}>
+              <AnimatedNumber
+                value={price.toFixed(isXtoY ? xDecimal : yDecimal)}
+                duration={300}
+                formatValue={formatNumbers()}
+              />
+              {showPrefix(price)} {tokenBSymbol}
+            </Typography>
+          </Grid>
         </Grid>
-
-        <SimpleInput
-          setValue={setMidPriceInput}
-          value={midPriceInput}
-          decimal={isXtoY ? xDecimal : yDecimal}
-          className={classes.midPrice}
-          placeholder='0.0'
-          globalPrice={globalPrice}
-        />
-
-        <Grid
-          className={classes.priceWrapper}
-          container
-          justifyContent='space-between'
-          alignItems='center'>
-          <Typography className={classes.priceLabel}>{tokenASymbol} starting price: </Typography>
-          <Typography className={classes.priceValue}>
-            <AnimatedNumber
-              value={price.toFixed(isXtoY ? xDecimal : yDecimal)}
-              duration={300}
-              formatValue={formatNumbers()}
-            />
-            {showPrefix(price)} {tokenBSymbol}
-          </Typography>
-        </Grid>
-
         <Typography className={classes.subheader}>Set price range</Typography>
         <Grid container className={classes.inputs}>
           <RangeInput

--- a/src/components/NewPosition/PoolInit/style.ts
+++ b/src/components/NewPosition/PoolInit/style.ts
@@ -5,8 +5,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   wrapper: {
     borderRadius: 10,
     backgroundColor: colors.invariant.component,
-    padding: 24,
-    paddingTop: 16,
+    padding: '16px 24px 8px 24px',
     flex: '1 1 0%'
   },
   header: {
@@ -19,7 +18,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     borderRadius: 8,
     backgroundColor: colors.invariant.component,
     width: '100%',
-    position: 'relative'
+    position: 'relative',
+    gap: 4
+  },
+  topInnerWrapper: {
+    minHeight: 283
   },
   subheader: {
     ...typography.heading4,

--- a/src/components/NewPosition/RangeSelector/style.ts
+++ b/src/components/NewPosition/RangeSelector/style.ts
@@ -5,8 +5,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   wrapper: {
     borderRadius: 10,
     backgroundColor: colors.invariant.component,
-    padding: 24,
-    paddingTop: 16,
+    padding: '16px 24px 8px 24px',
     flex: '1 1 0%'
   },
   headerContainer: {
@@ -21,7 +20,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     backgroundColor: colors.invariant.component,
     width: '100%',
     position: 'relative',
-    flex: '1 1 0%'
+    gap: 4
   },
   plot: {
     width: '100%',
@@ -29,11 +28,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   subheader: {
     ...typography.heading4,
-    marginBottom: 10,
-    color: colors.white.main,
-    [theme.breakpoints.down('sm')]: {
-      marginBlock: 16
-    }
+    marginBottom: 14,
+    color: colors.white.main
   },
   inputs: {
     marginBottom: 8,

--- a/src/components/PositionDetails/PositionDetails.tsx
+++ b/src/components/PositionDetails/PositionDetails.tsx
@@ -98,7 +98,6 @@ const PositionDetails: React.FC<IProps> = ({
             <Typography className={classes.backText}>Back to Liquidity Positions List</Typography>
           </Grid>
         </Link>
-
         <SinglePositionInfo
           fee={+printBN(fee.v, DECIMAL - 2)}
           onClickClaimFee={onClickClaimFee}

--- a/src/components/PositionDetails/SinglePositionInfo/style.ts
+++ b/src/components/PositionDetails/SinglePositionInfo/style.ts
@@ -3,7 +3,12 @@ import { colors, typography } from '@static/theme'
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
-    width: '100%'
+    width: '100%',
+    flexGrow: 1,
+
+    display: 'flex',
+    flexDirection: 'column'
+    // justifyContent: 'space-between'
   },
   iconsGrid: {
     display: 'flex',
@@ -100,7 +105,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     background: colors.invariant.component,
     marginTop: 20,
     padding: 24,
-    borderRadius: 24
+    borderRadius: 24,
+    flexGrow: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between'
   },
   iconSmall: {
     width: 20,

--- a/src/pages/SinglePositionPage/SinglePositionPage.tsx
+++ b/src/pages/SinglePositionPage/SinglePositionPage.tsx
@@ -12,7 +12,9 @@ export const SinglePositionPage: React.FC<IProps> = ({ id }) => {
 
   return (
     <Grid container className={classes.container} justifyContent='center'>
-      <SinglePositionWrapper id={id} />
+      <Grid item>
+        <SinglePositionWrapper id={id} />
+      </Grid>
     </Grid>
   )
 }


### PR DESCRIPTION
Change styles of position details and position pages to avoid resizing interfaces when the view is changing. 
For position details page equalize the heights of inner containers.

![image](https://github.com/invariant-labs/webapp/assets/93533892/1b002844-b2bc-4a77-a1ea-f3d49fb07417)
![image](https://github.com/invariant-labs/webapp/assets/93533892/0f571488-e601-454e-9d91-0c86d6b6b8ce)

